### PR TITLE
Fixed VS12 tuples handling

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,12 @@ FILE(GLOB srcs "*.cpp")
 
 INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/gtest")
 
+# VS2012 doesn't support correctly the tuples yet,
+# see http://code.google.com/p/googletest/issues/detail?id=412
+if(MSVC)
+    ADD_DEFINITIONS(/D _VARIADIC_MAX=10)
+endif()
+
 ADD_EXECUTABLE(${target} ${srcs} ${hdrs})
 TARGET_LINK_LIBRARIES(${target} gtest ${PRACTICE1_LIBRARY})
 


### PR DESCRIPTION
To get rid of `error C2977: 'std::tuple' : too many template arguments` under VS12
